### PR TITLE
Harden IO base handler SQL and add function tests

### DIFF
--- a/class/iobase.php
+++ b/class/iobase.php
@@ -35,6 +35,7 @@ class XtransamIobase extends XoopsObject
         $this->initVar('path', XOBJ_DTYPE_TXTBOX, null, true, 255);
         $this->initVar('languagefrom', XOBJ_DTYPE_INT, null);
         $this->initVar('languageto', XOBJ_DTYPE_INT, null);
+        $this->initVar('total', XOBJ_DTYPE_INT, null);
         $this->initVar('done', XOBJ_DTYPE_INT, null);
     }
 }
@@ -63,35 +64,46 @@ class XtransamIobaseHandler extends XoopsPersistableObjectHandler
             return false;
         }
 
+        $point        = $this->db->quoteString($io->getVar('point', 'n'));
+        $path         = $this->db->quoteString($io->getVar('path', 'n'));
+        $languageFrom = (int)$io->getVar('languagefrom', 'n');
+        $languageTo   = (int)$io->getVar('languageto', 'n');
+        $total        = (int)$io->getVar('total', 'n');
+        $done         = (int)$io->getVar('done', 'n');
+
         if (!$this->exists($io)) {
-            $sql = 'INSERT INTO ' . $this->db->prefix('xtransam_iobase') . " (`point`, `path`, `languagefrom`, `languageto`) VALUES ('" . $io->getVar('point') . "', '" . $io->getVar('path') . "', '" . $io->getVar('languagefrom') . "', '" . $io->getVar('languageto') . "')";
+            $sql = sprintf(
+                'INSERT INTO %s (`point`, `path`, `languagefrom`, `languageto`, `total`, `done`) VALUES (%s, %s, %d, %d, %d, %d)',
+                $this->db->prefix('xtransam_iobase'),
+                $point,
+                $path,
+                $languageFrom,
+                $languageTo,
+                $total,
+                $done
+            );
         } else {
-            $sql = 'UPDATE '
-                   . $this->db->prefix('xtransam_iobase')
-                   . " SET `point` = '"
-                   . $io->getVar('point')
-                   . "', `path` = '"
-                   . $io->getVar('path')
-                   . "', `languagefrom` = '"
-                   . $io->getVar('languagefrom')
-                   . "', `languageto` = '"
-                   . $io->getVar('languageto')
-                   . "', `total` = '"
-                   . $io->getVar('total')
-                   . "', `done` = '"
-                   . $io->getVar('done')
-                   . "' where `id` = "
-                   . $io->getVar('id');
+            $sql = sprintf(
+                'UPDATE %s SET `point` = %s, `path` = %s, `languagefrom` = %d, `languageto` = %d, `total` = %d, `done` = %d WHERE `id` = %d',
+                $this->db->prefix('xtransam_iobase'),
+                $point,
+                $path,
+                $languageFrom,
+                $languageTo,
+                $total,
+                $done,
+                (int)$io->getVar('id', 'n')
+            );
         }
 
-        return $this->db->queryF($sql);
+        return (bool)$this->db->queryF($sql);
     }
 
     public function &getObjects($criteria = null, $fields = null, $asObject = true, $id_as_key = true)
     {
         if (is_array($fields) && count($fields) > 0) {
-            if (!in_array($this->handler->keyName, $fields)) {
-                $fields[] = $this->handler->keyName;
+            if (!in_array($this->keyName, $fields)) {
+                $fields[] = $this->keyName;
             }
             $select = '`' . implode('`, `', $fields) . '`';
         } else {
@@ -108,9 +120,6 @@ class XtransamIobaseHandler extends XoopsPersistableObjectHandler
             }
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();
-        }
-        if (empty($orderSet)) {
-            // $sql .= " ORDER BY `{$this->handler->keyName}` DESC";
         }
         $result = $this->db->query($sql, $limit, $start);
         $ret    = [];

--- a/class/provider.php
+++ b/class/provider.php
@@ -79,7 +79,13 @@ class XtransamProviderHandler extends XoopsPersistableObjectHandler
 
     public function _unescapeUTF8EscapeSeq($str)
     {
-        return preg_replace_callback("/\\\u([0-9a-f]{4})/i", create_function('$matches', 'return html_entity_decode(\'&#x\'.$matches[1].\';\', ENT_NOQUOTES, \'UTF-8\');'), $str);
+        return preg_replace_callback(
+            "/\\\u([0-9a-f]{4})/i",
+            static function ($matches) {
+                return html_entity_decode('&#x' . $matches[1] . ';', ENT_NOQUOTES, 'UTF-8');
+            },
+            $str
+        );
     }
 
     public function clean($var)

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "xoops/xtransam",
+    "type": "project",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Xtransam\\Tests\\": "tests/"
+        }
+    }
+}

--- a/include/functions.php
+++ b/include/functions.php
@@ -136,8 +136,12 @@ if (!function_exists('xtransam_hex2bin')) {
             return null;
         }
         $r = '';
-        for ($a = 0; $a < strlen($hex); $a += 2) {
-            $r .= chr(hexdec($hex{$a} . $hex{$a + 1}));
+        $length = strlen($hex);
+        if (0 !== $length % 2) {
+            return null;
+        }
+        for ($a = 0; $a < $length; $a += 2) {
+            $r .= chr(hexdec($hex[$a] . $hex[$a + 1]));
         }
 
         return $r;
@@ -209,10 +213,16 @@ if (!function_exists('xtransam_callAPI')) {
             }
             curl_setopt($ch, CURLOPT_URL, $url);
             //curl_setopt($ch, CURLOPT_HEADER, 1);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+            $verifySsl = true;
+            if (defined('XTRANSAM_DISABLE_SSL_VERIFY') && true === XTRANSAM_DISABLE_SSL_VERIFY) {
+                $verifySsl = false;
+            }
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $verifySsl ? 1 : 0);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $verifySsl ? 2 : 0);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_USERAGENT, ucfirst($GLOBALS['xoopsModule']->getVar('dirname')) . ' ' . $GLOBALS['xoopsModule']->getVar('version') / 100 . ' (PHP Version ' . PHP_VERSION . ')');
+            $moduleName    = isset($GLOBALS['xoopsModule']) ? ucfirst($GLOBALS['xoopsModule']->getVar('dirname')) : 'xtransam';
+            $moduleVersion = isset($GLOBALS['xoopsModule']) ? ((int)$GLOBALS['xoopsModule']->getVar('version') / 100) : '1.0';
+            curl_setopt($ch, CURLOPT_USERAGENT, $moduleName . ' ' . $moduleVersion . ' (PHP Version ' . PHP_VERSION . ')');
             $data = curl_exec($ch);
             curl_close($ch);
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="XTransam Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Xtransam\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class FunctionsTest extends TestCase
+{
+    /**
+     * @return array<string, array{0:string}>
+     */
+    public function storeMethodProvider(): array
+    {
+        return [
+            'urlcode' => ['urlcode'],
+            'base64'  => ['base64'],
+            'uucode'  => ['uucode'],
+            'open'    => ['open'],
+            'hex'     => ['hex'],
+        ];
+    }
+
+    /**
+     * @dataProvider storeMethodProvider
+     */
+    public function testConvertEncodeDecodeRoundTrip(string $method): void
+    {
+        $value = 'Tést value with symbols % and unicode ✓';
+
+        $encoded = xtransam_convert_encode($value, $method);
+        $decoded = xtransam_convert_decode($encoded, $method);
+
+        if ('hex' === $method) {
+            self::assertNotNull($decoded);
+        }
+
+        $this->assertSame($value, $decoded);
+    }
+
+    public function testHex2BinRejectsOddLength(): void
+    {
+        $this->assertNull(xtransam_hex2bin('abc'));
+    }
+
+    public function testHex2BinConvertsEvenLengthStrings(): void
+    {
+        $this->assertSame('AB', xtransam_hex2bin('4142'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+
+if (!defined('XOOPS_URL')) {
+    define('XOOPS_URL', 'https://example.com');
+}
+
+if (!defined('XOOPS_ROOT_PATH')) {
+    define('XOOPS_ROOT_PATH', __DIR__ . '/../xoops_root');
+}
+
+require_once __DIR__ . '/../include/functions.php';


### PR DESCRIPTION
## Summary
- add initialization for the IO base total counter and sanitize SQL statements
- replace deprecated UTF-8 unescape helper and strengthen encoding utilities
- add PHPUnit configuration with tests covering conversion helpers

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e25c024a6c8323be060e301f30b399